### PR TITLE
Fix: miners expose item capability on first placement (1.20.1-1.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.20.1-1.5.2
+- Fix: Preserve ITEM capability when reconfiguring energy storage to allow pipe extraction without relog.
+- Fix: Clamp energy removal at 0 to avoid negative energy edge cases.
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=Void Miners
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.20.1-1.5.1
+mod_version=1.20.1-1.5.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/leo/voidminers/block/entity/ControllerBaseBE.java
+++ b/src/main/java/com/leo/voidminers/block/entity/ControllerBaseBE.java
@@ -84,7 +84,10 @@ public class ControllerBaseBE extends BlockEntity {
     }
 
     public void setupEnergyStorage() {
-        invalidateCaps();
+        // Only invalidate and recreate the energy capability; keep item capability intact
+        if (lazyEnergyHandler != null) {
+            lazyEnergyHandler.invalidate();
+        }
         int storage = ConfigLoader.getInstance().getMinerConfig(name).energyStorage();
 
         if (!ConfigLoader.getInstance().ALLOW_NO_ENERGY_MINERS && storage <= 0) storage = ENERGY_CAPACITY;

--- a/src/main/java/com/leo/voidminers/energy/ModEnergyStorage.java
+++ b/src/main/java/com/leo/voidminers/energy/ModEnergyStorage.java
@@ -24,7 +24,7 @@ public class ModEnergyStorage extends EnergyStorage {
     }
 
     public void removeEnergy(int remove) {
-        this.energy -= remove;
+        this.energy = Math.max(0, this.energy - remove);
     }
 
     public void addEnergy(int add) {


### PR DESCRIPTION
This PR fixes the issues tracked in #16:

- Pipes/conduits not connecting until relog on first placement
- Miner consuming FE but output not extractable on first run
- Edge case where energy could go negative

Changes
- Only invalidate ENERGY capability when reconfiguring energy storage; keep ITEM capability alive so extraction pipes discover it immediately.
  - `ControllerBaseBE#setupEnergyStorage()`: stop calling `invalidateCaps()`; instead invalidate only `lazyEnergyHandler` and recreate it.
- Clamp energy removal at 0 in `ModEnergyStorage#removeEnergy`.
- Bump version to `1.20.1-1.5.2`.

Why
- `invalidateCaps()` invalidated both ENERGY and ITEM `LazyOptional`s during first-time setup, then only ENERGY was recreated. Until a reload, ITEM capability stayed invalid → pipes could not connect and extract.
- Clamping energy strengthens correctness for future edge cases.

Validation
- Built the mod and verified that on a fresh placement, pipes (Mekanism/Pipez/EnderIO) connect and extract immediately without relog; miner generates items as expected while powered.

This should resolve #16 for 1.20.1 users.
